### PR TITLE
Upgrade to cson-safe v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tmp": "0.0.24"
   },
   "dependencies": {
-    "cson-safe": "^0.1.1",
+    "cson-safe": "^1.0.0",
     "underscore": "^1.7.0"
   }
 }


### PR DESCRIPTION
The big change in v1.0.0 is that cson-safe now uses coffee-script
instead of -redux for parsing. This leads to less confusing behavior in
the subtle cases where -redux does not match coffee-script behavior. It
also collapses the dependency tree from a gazillion packages down to
one.
