### PR TITLE
Publish to npmjs.org with npm 3+ only

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 src/
 test/
+coverage/
 .travis.yml
 Gruntfile.coffee

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
 - '5.0'
 - '4.2'
 - '0.12'
-- '0.11'
-- '0.10'
 - iojs
 env:
 - NODE_ENV=development
@@ -19,4 +17,5 @@ deploy:
     secure: FpFRu5T0+kNImKSV7oE44fhufg2V9W/fTkEsmx1oojWohE8s9wCczhTSupMt6agVZzQzgtSuiQtAFn6x3oHW4PG1YWTWiMEjq3I2AbFahDXXTuwGNDbqXN1BzhUi222ZB3Zxo5khJvKCH7J392wAYUvrC5YSHqkCakX3xe3Dv6E=
   on:
     tags: true
+    node: '5.0'
     repo: cybertk/csonschema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csonschema",
-  "version": "0.5.2",
+  "version": "0.5.3-beta.1",
   "description": "Write jsonschema with cson",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Changes

- Remove `coverage/` dir in final npm package
- Lock to npm 3+ when deploy to npm

This PR also fixed https://github.com/cybertk/csonschema/issues/11